### PR TITLE
Create curl-opensslonly formula.

### DIFF
--- a/Formula/curl-opensslonly.rb
+++ b/Formula/curl-opensslonly.rb
@@ -18,7 +18,7 @@ class CurlOpensslonly < Formula
     depends_on "libtool" => :build
   end
 
-  keg_only :provided_by_macos
+  keg_only :shadowed_by_macos, "macOS provides curl"
 
   depends_on "pkg-config" => :build
   depends_on "brotli"

--- a/Formula/curl-opensslonly.rb
+++ b/Formula/curl-opensslonly.rb
@@ -1,0 +1,75 @@
+class CurlOpensslonly < Formula
+  desc "Get a file from an HTTP, HTTPS or FTP server"
+  homepage "https://curl.haxx.se/"
+  url "https://curl.haxx.se/download/curl-7.74.0.tar.bz2"
+  sha256 "0f4d63e6681636539dc88fa8e929f934cd3a840c46e0bf28c73be11e521b77a5"
+  license "curl"
+
+  livecheck do
+    url "https://curl.haxx.se/download/"
+    regex(/href=.*?curl[._-]v?(.*?)\.t/i)
+  end
+
+  head do
+    url "https://github.com/curl/curl.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
+  keg_only :provided_by_macos
+
+  depends_on "pkg-config" => :build
+  depends_on "brotli"
+  depends_on "libidn2"
+  depends_on "libmetalink"
+  depends_on "libssh2"
+  depends_on "nghttp2"
+  depends_on "openldap"
+  depends_on "openssl@1.1"
+  depends_on "rtmpdump"
+  depends_on "zstd"
+
+  uses_from_macos "zlib"
+
+  def install
+    system "./buildconf" if build.head?
+
+    openssl = Formula["openssl@1.1"]
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --with-ssl=#{openssl.opt_prefix}
+      --with-ca-bundle=#{openssl.pkgetc}/cert.pem
+      --with-ca-path=#{openssl.pkgetc}/certs
+      --with-secure-transport
+      --with-default-ssl-backend=openssl
+      --with-gssapi
+      --with-libidn2
+      --with-libmetalink
+      --with-librtmp
+      --with-libssh2
+      --without-libpsl
+    ]
+
+    system "./configure", *args
+    system "make", "install"
+    system "make", "install", "-C", "scripts"
+    libexec.install "lib/mk-ca-bundle.pl"
+  end
+
+  test do
+    # Fetch the curl tarball and see that the checksum matches.
+    # This requires a network connection, but so does Homebrew in general.
+    filename = (testpath/"test.tar.gz")
+    system "#{bin}/curl", "-L", stable.url, "-o", filename
+    filename.verify_checksum stable.checksum
+
+    system libexec/"mk-ca-bundle.pl", "test.pem"
+    assert_predicate testpath/"test.pem", :exist?
+    assert_predicate testpath/"certdata.txt", :exist?
+  end
+end

--- a/Formula/curl-opensslonly.rb
+++ b/Formula/curl-opensslonly.rb
@@ -45,7 +45,6 @@ class CurlOpensslonly < Formula
       --with-ssl=#{openssl.opt_prefix}
       --with-ca-bundle=#{openssl.pkgetc}/cert.pem
       --with-ca-path=#{openssl.pkgetc}/certs
-      --with-secure-transport
       --with-default-ssl-backend=openssl
       --with-gssapi
       --with-libidn2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Junohq Tap
+# Juno Homebrew Tap
+
+This repo contains a [Homebrew tap](https://docs.brew.sh/Taps) with the following forumlae:
+
+* `curl-opensslonly` - A fork of the curl formula without secure-transport to
+  allow pycurl versions prior to 7.43.0.6 to work (celery[sqs] requires
+  7.43.0.5)
 
 ## How do I install these formulae?
 `brew install junohq/tap/<formula>`


### PR DESCRIPTION
We want a version of curl that's only compiled against openssl.

pycurl 7.43.0.5 doesn't work with libcurl when it's compiled against
this as well as openssl - it can't detect which SSL backend libcurl is
using and raises an error at runtime.

pycurl 7.43.0.6 fixes this issue, but we can't upgrade to that version
until celery[sqs] has been updated to allow that version (it currently
has an exact dependency on 7.43.0.5 of pycurl)